### PR TITLE
split iceflux diag and bug fix

### DIFF
--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -719,7 +719,7 @@ contains
           write(message,'(a31,e24.16)') 'Total ice cap removal (Gt/y)   ', tot_rmicecap_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-          write(message,'(31,e24.16)') 'Total dmass/dt (Gt/y)           ', tot_dmass_dt * factor
+          write(message,'(a31,e24.16)') 'Total dmass/dt (Gt/y)          ', tot_dmass_dt * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
           write(message,'(a31,e24.16)') 'dmass/dt error (Gt/y)          ', err_dmass_dt * factor

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -676,22 +676,13 @@ contains
 
        if (model%options%dm_dt_diag == DM_DT_DIAG_KG_S) then
 
-          write(message,'(a25,e24.16)') 'Total SMB flux (kg/s)    ', tot_smb_flux
+          write(message,'(a31,e24.16)') 'Total SMB flux (kg/s)          ', tot_smb_flux
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-          write(message,'(a25,e24.16)') 'Total BMB flux (kg/s)    ', tot_bmb_flux
+          write(message,'(a31,e24.16)') 'Total BMB flux (kg/s)          ', tot_bmb_flux
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-          write(message,'(a25,e24.16)') 'Total calving flux (kg/s)', tot_calving_flux
-          call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-          write(message,'(a25,e24.16)') 'Total dmass/dt (kg/s)    ', tot_dmass_dt
-          call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-          write(message,'(a25,e24.16)') 'dmass/dt error (kg/s)    ', err_dmass_dt
-          call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-          write(message,'(a25,e24.16)') 'Total gr line flux (kg/s)', tot_gl_flux
+          write(message,'(a31,e24.16)') 'Total calving flux (kg/s)      ', tot_calving_flux
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
           write(message,'(a31,e24.16)') 'Total retreat mask flux (kg/s) ', tot_forceretreat_flux
@@ -700,32 +691,41 @@ contains
           write(message,'(a31,e24.16)') 'Total ice cap removal (kg/s)   ', tot_rmicecap_flux
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
+          write(message,'(a31,e24.16)') 'Total dmass/dt (kg/s)          ', tot_dmass_dt
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a31,e24.16)') 'dmass/dt error (kg/s)          ', err_dmass_dt
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a25,e24.16)') 'Total gr line flux (kg/s)', tot_gl_flux
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
        elseif (model%options%dm_dt_diag == DM_DT_DIAG_GT_Y) then
 
           factor = scyr / 1.0d12
 
-          write(message,'(a25,e24.16)') 'Total SMB flux (Gt/y)    ', tot_smb_flux * factor
+          write(message,'(a31,e24.16)') 'Total SMB flux (Gt/y)          ', tot_smb_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-          write(message,'(a25,e24.16)') 'Total BMB flux (Gt/y)    ', tot_bmb_flux * factor
+          write(message,'(a31,e24.16)') 'Total BMB flux (Gt/y)          ', tot_bmb_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-          write(message,'(a25,e24.16)') 'Total calving flux (Gt/y)', tot_calving_flux * factor
-          call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-          write(message,'(a25,e24.16)') 'Total dmass/dt (Gt/y)    ', tot_dmass_dt * factor
-          call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-          write(message,'(a25,e24.16)') 'dmass/dt error (Gt/y)    ', err_dmass_dt * factor
-          call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-          write(message,'(a25,e24.16)') 'Total gr line flux (Gt/y)', tot_gl_flux * factor
+          write(message,'(a31,e24.16)') 'Total calving flux (Gt/y)      ', tot_calving_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
           write(message,'(a31,e24.16)') 'Total retreat mask flux (Gt/y) ', tot_forceretreat_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
           write(message,'(a31,e24.16)') 'Total ice cap removal (Gt/y)   ', tot_rmicecap_flux * factor
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(31,e24.16)') 'Total dmass/dt (Gt/y)           ', tot_dmass_dt * factor
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a31,e24.16)') 'dmass/dt error (Gt/y)          ', err_dmass_dt * factor
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a25,e24.16)') 'Total gr line flux (Gt/y)', tot_gl_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        endif   ! dm_dt_diag

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -602,7 +602,8 @@ contains
        ! mass conservation error
        ! Note: For most runs, this should be close to zero.
 
-       err_dmass_dt = tot_dmass_dt - (tot_smb_flux + tot_bmb_flux + tot_calving_flux)
+       err_dmass_dt = tot_dmass_dt - (tot_smb_flux + tot_bmb_flux + tot_calving_flux &
+                                      + tot_forceretreat_flux + tot_rmicecap_flux)
 
        ! uncomment to convert total fluxes from kg/s to Gt/yr
 !!!    tot_smb_flux = tot_smb_flux * scyr/1.0d12

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -195,6 +195,8 @@ contains
          tot_smb_flux,                  &    ! total surface mass balance flux (kg/s)
          tot_bmb_flux,                  &    ! total basal mass balance flux (kg/s)
          tot_calving_flux,              &    ! total calving flux (kg/s)
+         tot_forceretreat_flux,         &    ! total force retreat flux (kg/s)
+         tot_rmicecap_flux,             &    ! total ice cap removal flux (kg/s)
          tot_gl_flux,                   &    ! total grounding line flux (kg/s)
          tot_acab,                      &    ! total surface accumulation/ablation rate (m^3/yr)
          tot_bmlt,                      &    ! total basal melt rate (m^3/yr)
@@ -548,6 +550,19 @@ contains
        ! total calving mass balance flux (kg/s, negative for ice loss by calving)
        tot_calving_flux = -tot_calving * rhoi / scyr   ! convert m^3/yr to kg/s
 
+       ! total force retreat and ice cap removal fluxes (kg/s, negative for ice loss)
+       ! Note: forceretreat_flux and rmicecap_flux are in kg/m^2/s; multiply by cell_area to get kg/s
+       tot_forceretreat_flux = 0.d0
+       tot_rmicecap_flux = 0.d0
+       do j = lhalo+1, nsn-uhalo
+          do i = lhalo+1, ewn-uhalo
+             tot_forceretreat_flux = tot_forceretreat_flux + model%geometry%forceretreat_flux(i,j) * cell_area(i,j)
+             tot_rmicecap_flux     = tot_rmicecap_flux     + model%geometry%rmicecap_flux(i,j)     * cell_area(i,j)
+          enddo
+       enddo
+       tot_forceretreat_flux = parallel_reduce_sum(tot_forceretreat_flux)
+       tot_rmicecap_flux     = parallel_reduce_sum(tot_rmicecap_flux)
+
        ! mean calving rate (m/yr)
        ! Note: This will be only approximate if some ice has melted completely during the time step
        if (tot_area > eps) then
@@ -602,6 +617,8 @@ contains
        model%geometry%total_smb_flux = tot_smb_flux
        model%geometry%total_bmb_flux = tot_bmb_flux
        model%geometry%total_calving_flux = tot_calving_flux
+       model%geometry%total_forceretreat_flux = tot_forceretreat_flux
+       model%geometry%total_rmicecap_flux = tot_rmicecap_flux
        model%geometry%total_gl_flux = tot_gl_flux
 
     endif  ! Glissade dycore

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -693,6 +693,12 @@ contains
           write(message,'(a25,e24.16)') 'Total gr line flux (kg/s)', tot_gl_flux
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
+          write(message,'(a31,e24.16)') 'Total retreat mask flux (kg/s) ', tot_forceretreat_flux
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a31,e24.16)') 'Total ice cap removal (kg/s)   ', tot_rmicecap_flux
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
        elseif (model%options%dm_dt_diag == DM_DT_DIAG_GT_Y) then
 
           factor = scyr / 1.0d12
@@ -713,6 +719,12 @@ contains
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
           write(message,'(a25,e24.16)') 'Total gr line flux (Gt/y)', tot_gl_flux * factor
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a31,e24.16)') 'Total retreat mask flux (Gt/y) ', tot_forceretreat_flux * factor
+          call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+          write(message,'(a31,e24.16)') 'Total ice cap removal (Gt/y)   ', tot_rmicecap_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        endif   ! dm_dt_diag

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1270,6 +1270,10 @@ module glide_types
     real(dp),dimension(:,:),  pointer :: basal_mbal_flux_tavg =>null() !> basal mass balance (kg m^-2 s^-1, time average)
     real(dp),dimension(:,:),  pointer :: calving_flux =>null()         !> calving flux (kg m^-2 s^-1), diagnosed from calving_thck
     real(dp),dimension(:,:),  pointer :: calving_flux_tavg =>null()    !> calving flux (kg m^-2 s^-1, time average)
+    real(dp),dimension(:,:),  pointer :: forceretreat_flux =>null()      !> flux due to force retreat (kg m^-2 s^-1)
+    real(dp),dimension(:,:),  pointer :: forceretreat_flux_tavg =>null() !>    time average
+    real(dp),dimension(:,:),  pointer :: rmicecap_flux =>null()          !> flux due to ice cap removal (kg m^-2 s^-1)
+    real(dp),dimension(:,:),  pointer :: rmicecap_flux_tavg =>null()     !>    time average
     real(dp),dimension(:,:),  pointer :: gl_flux_east =>null()         !> mass flux eastward at grounding line, edge-based (kg m^-1 s^-1)
     real(dp),dimension(:,:),  pointer :: gl_flux_north =>null()        !> mass flux northward at grounding line, edge_based (kg m^-1 s^-1)
     real(dp),dimension(:,:),  pointer :: gl_flux =>null()              !> mass flux at grounding line, cell-based (kg m^-1 s^-1)
@@ -1318,10 +1322,14 @@ module glide_types
     real(dp) :: total_smb_flux         ! total surface mass balance flux (kg/s)
     real(dp) :: total_bmb_flux         ! total basal mass balance flux (kg/s)
     real(dp) :: total_calving_flux     ! total calving mass flux (kg/s)
+    real(dp) :: total_forceretreat_flux! total flux due to force retreat (kg/s) 
+    real(dp) :: total_rmicecap_flux    ! total flux due to ice cap removal (kg/s) 
     real(dp) :: total_gl_flux          ! total grounding line mass flux (kg/s)
     real(dp) :: total_smb_flux_tavg    ! total surface mass balance flux (kg/s), time average
     real(dp) :: total_bmb_flux_tavg    ! total basal mass balance flux (kg/s), time average
     real(dp) :: total_calving_flux_tavg! total calving mass flux (kg/s), time average
+    real(dp) :: total_forceretreat_flux_tavg ! total flux due to force retreat (kg/s), time average
+    real(dp) :: total_rmicecap_flux_tavg     ! total flux due to ice cap removal (kg/s), time average
     real(dp) :: total_gl_flux_tavg     ! total grounding line mass flux (kg/s), time average
 
   end type glide_geometry
@@ -1574,6 +1582,8 @@ module glide_types
   type glide_calving
      !> holds fields and parameters related to calving
      real(dp),dimension(:,:),  pointer :: calving_thck => null()   !> thickness loss in grid cell due to calving during one time step (m)
+     real(dp),dimension(:,:),  pointer :: forceretreat_thck => null() !> thickness loss in grid cell due to force retreat during one time step (m)
+     real(dp),dimension(:,:),  pointer :: rmicecap_thck => null()     !> thickness loss in grid cell due to ice cap removal during one time step (m)
      real(dp),dimension(:,:),  pointer :: calving_rate => null()   !> rate of ice loss due to calving (m/yr ice)
      real(dp),dimension(:,:),  pointer :: calving_rate_tavg => null()  !> rate of ice loss due to calving (m/yr ice, time average)
      integer, dimension(:,:),  pointer :: calving_mask => null()   !> calve floating ice where the mask = 1 (whichcalving = CALVING_GRID_MASK)
@@ -3100,6 +3110,10 @@ contains
     call coordsystem_allocate(model%general%ice_grid, model%geometry%basal_mbal_flux_tavg)
     call coordsystem_allocate(model%general%ice_grid, model%geometry%calving_flux)
     call coordsystem_allocate(model%general%ice_grid, model%geometry%calving_flux_tavg)
+    call coordsystem_allocate(model%general%ice_grid, model%geometry%forceretreat_flux)
+    call coordsystem_allocate(model%general%ice_grid, model%geometry%forceretreat_flux_tavg)
+    call coordsystem_allocate(model%general%ice_grid, model%geometry%rmicecap_flux)
+    call coordsystem_allocate(model%general%ice_grid, model%geometry%rmicecap_flux_tavg)
     call coordsystem_allocate(model%general%ice_grid, model%geometry%gl_flux_east)
     call coordsystem_allocate(model%general%ice_grid, model%geometry%gl_flux_north)
     call coordsystem_allocate(model%general%ice_grid, model%geometry%gl_flux)
@@ -3319,6 +3333,8 @@ contains
 
     ! calving arrays
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_thck)
+    call coordsystem_allocate(model%general%ice_grid, model%calving%forceretreat_thck)
+    call coordsystem_allocate(model%general%ice_grid, model%calving%rmicecap_thck)
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_rate)
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_rate_tavg)
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_mask)
@@ -3857,6 +3873,14 @@ contains
         deallocate(model%geometry%calving_flux)
     if (associated(model%geometry%calving_flux_tavg)) &
         deallocate(model%geometry%calving_flux_tavg)
+    if (associated(model%geometry%forceretreat_flux)) &
+        deallocate(model%geometry%forceretreat_flux)
+    if (associated(model%geometry%forceretreat_flux_tavg)) &
+        deallocate(model%geometry%forceretreat_flux_tavg)
+    if (associated(model%geometry%rmicecap_flux)) &
+        deallocate(model%geometry%rmicecap_flux)
+    if (associated(model%geometry%rmicecap_flux_tavg)) &
+        deallocate(model%geometry%rmicecap_flux_tavg)
     if (associated(model%geometry%gl_flux_east)) &
         deallocate(model%geometry%gl_flux_east)
     if (associated(model%geometry%gl_flux_north)) &
@@ -3983,6 +4007,10 @@ contains
     ! calving arrays
     if (associated(model%calving%calving_thck)) &
         deallocate(model%calving%calving_thck)
+    if (associated(model%calving%forceretreat_thck)) &
+        deallocate(model%calving%forceretreat_thck)
+    if (associated(model%calving%rmicecap_thck)) &
+        deallocate(model%calving%rmicecap_thck)
     if (associated(model%calving%calving_rate)) &
         deallocate(model%calving%calving_rate)
     if (associated(model%calving%calving_rate_tavg)) &

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -544,6 +544,18 @@ units:         meter
 long_name:     thickness of calving ice
 data:          data%calving%calving_thck
 
+[forceretreat_thck]
+dimensions:    time, y1, x1
+units:         meter
+long_name:     ice removed with force_retreat method
+data:          data%calving%forceretreat_thck
+
+[rmicecap_thck]
+dimensions:    time, y1, x1
+units:         meter
+long_name:     ice removed with remove ice cap method
+data:          data%calving%rmicecap_thck
+
 [calving_rate]
 dimensions:    time, y1, x1
 units:         meter/year
@@ -691,6 +703,20 @@ dimensions:    time
 units:         kg/s
 long_name:     total calving mass balance flux
 data:          data%geometry%total_calving_flux
+average:       1
+
+[total_forceretreat_flux]
+dimensions:    time
+units:         kg/s
+long_name:     mass flux removed by force_retreat method
+data:          data%geometry%total_forceretreat_flux
+average:       1
+
+[total_rmicecap_flux]
+dimensions:    time
+units:         kg/s
+long_name:     mass flux removed by remove icecaps method
+data:          data%geometry%total_rmicecap_flux
 average:       1
 
 [thkmask]
@@ -1569,6 +1595,20 @@ units:         kg/m2/s
 long_name:     calving flux
 data:          data%geometry%calving_flux
 standard_name: land_ice_specific_mass_flux_due_to_calving
+average:       1
+
+[forceretreat_flux]
+dimensions:    time, y1, x1
+units:         kg/m2/s
+long_name:     forceretreat flux
+data:          data%geometry%forceretreat_flux
+average:       1
+
+[rmicecap_flux]
+dimensions:    time, y1, x1
+units:         kg/m2/s
+long_name:     remove_icecaps flux
+data:          data%geometry%rmicecap_flux
 average:       1
 
 [gl_flux]

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2538,7 +2538,7 @@ contains
                 model%geometry%thck(i,j) = model%geometry%thck(i,j) - dthck
                 ! record changes due to retreat forcing to separate field
                 !model%calving%calving_thck(i,j) = model%calving%calving_thck(i,j) + dthck
-                model%calving%forceretreat_thck(i,j) = dthck
+                model%calving%forceretreat_thck(i,j) = model%calving%forceretreat_thck(i,j) + dthck
              endif
           enddo
        enddo

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2516,7 +2516,7 @@ contains
     ! In the current version, weakly grounded cells (i.e., cells with f_ground < f_ground_threshold)
     !  are alse removed.
 
-    if (model%options%force_retreat == FORCE_RETREAT_ALL_ICE .and. model%options%calving_init == CALVING_INIT_OFF) then
+    if (model%options%force_retreat == FORCE_RETREAT_ALL_ICE .and. .not.init_calving) then
        if (this_rank == rtest) then
           write(iulog,*) 'Forcing retreat using ice_fraction_retreat_mask, time =', model%numerics%time
        endif

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -71,7 +71,7 @@ module glissade
 
   integer, private, parameter :: dummyunit=99
   logical, parameter :: verbose_glissade = .false.
-  logical, parameter :: verbose_retreat = .false.
+  logical, parameter :: verbose_retreat = .true.
 
   ! Change any of the following logical parameters to true to carry out simple tests
   logical, parameter :: test_transport = .false.    ! if true, call test_transport subroutine
@@ -1216,6 +1216,8 @@ contains
     ! can remove unprotected ice that counts toward the calving flux.
     !TODO - Move this calculation?
     model%calving%calving_thck = 0.0d0
+    model%calving%forceretreat_thck = 0.0d0
+    model%calving%rmicecap_thck = 0.0d0
 
     ! ------------------------------------------------------------------------
     ! Calculate isostatic adjustment
@@ -2534,7 +2536,9 @@ contains
                      * (1.0d0 - model%geometry%ice_fraction_retreat_mask(i,j))
                 dthck = model%geometry%thck(i,j) - min(maxthck, model%geometry%thck(i,j))
                 model%geometry%thck(i,j) = model%geometry%thck(i,j) - dthck
-                model%calving%calving_thck(i,j) = model%calving%calving_thck(i,j) + dthck
+                ! record changes due to retreat forcing to separate field
+                !model%calving%calving_thck(i,j) = model%calving%calving_thck(i,j) + dthck
+                model%calving%forceretreat_thck(i,j) = dthck
              endif
           enddo
        enddo
@@ -3252,7 +3256,9 @@ contains
        !       it will show where ice caps existed before they were removed.
 
        where (model%geometry%ice_cap_mask == 1)
-          model%calving%calving_thck = model%calving%calving_thck + model%geometry%thck
+          ! record changes due to ice cap removal to separate field
+          !model%calving%calving_thck = model%calving%calving_thck + model%geometry%thck
+          model%calving%rmicecap_thck = model%geometry%thck
           model%geometry%thck = 0.0d0
        endwhere
 
@@ -3876,6 +3882,8 @@ contains
     model%geometry%sfc_mbal_flux(:,:) = rhoi * model%climate%acab_applied(:,:)
     model%geometry%basal_mbal_flux(:,:) = rhoi * (-model%basal_melt%bmlt_applied(:,:))
     model%geometry%calving_flux(:,:) = rhoi * (-model%calving%calving_thck(:,:)) / model%numerics%dt
+    model%geometry%forceretreat_flux(:,:) = rhoi * (-model%calving%forceretreat_thck(:,:)) / model%numerics%dt
+    model%geometry%rmicecap_flux(:,:) = rhoi * (-model%calving%rmicecap_thck(:,:)) / model%numerics%dt
 
     ! calving rate (m/yr ice; positive for calving)
     model%calving%calving_rate(:,:) = model%calving%calving_thck(:,:) / (model%numerics%dt/scyr)

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -3258,7 +3258,7 @@ contains
        where (model%geometry%ice_cap_mask == 1)
           ! record changes due to ice cap removal to separate field
           !model%calving%calving_thck = model%calving%calving_thck + model%geometry%thck
-          model%calving%rmicecap_thck = model%geometry%thck
+          model%calving%rmicecap_thck = model%calving%rmicecap_thck + model%geometry%thck
           model%geometry%thck = 0.0d0
        endwhere
 


### PR DESCRIPTION
This PR fixes the logic when the retreat masking is applied, which didn't happen before. This is answer-changing in the standalone tests I ran because now the masks are applied when provided and they remove additional mass. But since we do not have an answer yet, it doesn't matter that it is answer-changing, I assume.  

This PR also splits the calving flux in the diagnostic output into 1. physical calving flux, 2. flux due to retreat mask and 3. flux due to ica cap removal. This was actually the main reason for this development, which uncovered the bug above. 
