### PR TITLE
Add 'frontal_melt_factor' in melt implementation and config parameter to tune frontal melt

### DIFF
--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -1460,8 +1460,16 @@ contains
     if (model%options%whichsmmelt < 0 .or. model%options%whichsmmelt >= size(submarine_melt)) then
        call write_log('Error, submarine_melt out of range',GM_FATAL)
     end if
-    write(message,*) 'submarine_melt           : ', model%options%whichsmmelt, submarine_melt(model%options%whichsmmelt)
+    write(message,*) 'submarine_melt          : ', model%options%whichsmmelt, submarine_melt(model%options%whichsmmelt)
     call write_log(message)
+    if (model%options%whichsmmelt == SMMELT_RATE) then
+       write(message,*) ' frontal_melt_rate =', model%calving%frontal_melt_rate
+       call write_log(message)
+    end if
+    if (model%options%whichsmmelt == SMMELT_ISMIP6) then
+       write(message,*) ' frontal_melt_factor =', model%calving%frontal_melt_factor
+       call write_log(message)
+    end if
 
     if (model%options%whichcalving < 0 .or. model%options%whichcalving >= size(marine_margin)) then
        call write_log('Error, marine_margin out of range',GM_FATAL)
@@ -1543,7 +1551,7 @@ contains
            (model%options%whichcalving /= CALVING_FLOAT_ZERO) )  then
           call write_log('Error, SMMELT options require calving option CALVING_FLOAT_ZERO',GM_FATAL)
        end if
-
+       
        if (model%options%adjust_input_thickness) then
           write(message,*) ' Input ice thickness will be adjusted based on surface and bed topography'
           call write_log(message)
@@ -2334,7 +2342,8 @@ contains
     call GetValue(section,'f_ground_threshold', model%calving%f_ground_threshold)
     call GetValue(section,'cf_advance_retreat_amplitude', model%calving%cf_advance_retreat_amplitude)
     call GetValue(section,'cf_advance_retreat_period',    model%calving%cf_advance_retreat_period)
-    call GetValue(section,'frontal_melt_rate', model%calving%frontal_melt_rate)
+    call GetValue(section,'frontal_melt_rate',  model%calving%frontal_melt_rate)
+    call GetValue(section,'frontal_melt_factor',  model%calving%frontal_melt_factor)
 
     ! NOTE: bpar is used only for BTRC_TANH_BWAT
     !       btrac_max and btrac_slope are used (with btrac_const) for BTRC_LINEAR_BMLT

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1646,7 +1646,11 @@ module glide_types
           cf_advance_retreat_period = 0.0d0      !> period (yr) for an advance/retreat cycle
                                                  !> period = 0 => constant amplitude
      real(dp) :: &
-          frontal_melt_rate = 0.0d0              !> frontal submarine melt rate, like lateral retreat rate at MF (m/yr) 
+          frontal_melt_rate = 0.0d0              !> frontal submarine melt rate, like lateral retreat rate at MF (m/yr)
+     real(dp) :: &
+          frontal_melt_factor = 1.0d0            !> multiplier for Rignot frontal melt. A value of 1.6 was proposed for ISMIP7
+                                                 !> based on new obs. This may also be used for sampling uncertainty and 
+                                                 !> to correct for resolution depencence
 
   end type glide_calving
 

--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -1171,6 +1171,7 @@ contains
                dx,                 dy,                    &
                dt,                 time,                  &  ! s
                itest,   jtest,     rtest,                 &
+               calving%frontal_melt_factor,               & ! 1; multiplier
                calving%melt_front_mask,                   &
                calving%thermal_forcing_applied,           &  ! degC
                calving%runoff_applied/1000.,              &  ! m/s; (read from file in kg/m2/s)
@@ -1306,6 +1307,7 @@ contains
                dx,                 dy,                    &
                dt,                 time,                  &  ! s
                itest,   jtest,     rtest,                 &
+               calving%frontal_melt_factor,                       & ! 1; multiplier
                calving%melt_front_mask,                   &
                calving%thermal_forcing_applied,           &  ! degC
                calving%runoff_applied/1000.,              &  ! m/s; (read from file in kg/m2/s)
@@ -2881,6 +2883,7 @@ contains
        dx,                 dy,             &
        dt,                 time,           &  ! s
        itest,   jtest,     rtest,          &
+       frontal_melt_factor,                & ! 1; multiplier
        melt_front_mask,                    &
        thermal_forcing_applied,            &  ! degC
        runoff_applied,                     &  ! m/s
@@ -2906,6 +2909,9 @@ contains
          dx, dy,                 & ! grid cell size (m)
          dt,                     & ! time step (s)
          time                      ! elapsed time (s) of model run
+
+    real(dp), intent(in) :: &
+         frontal_melt_factor       ! multiplier for Rignot melt parameterisation
 
     integer, dimension(nx,ny), intent(in)  ::  &
          melt_front_mask           ! = 1 where ice is grounded below sealevel or floating and borders at least one ocean cell, else = 0
@@ -2964,10 +2970,9 @@ contains
 
              tf_sr = thermal_forcing_applied(i,j) ! 2d thermal forcing [degC]
              q_sr = runoff_applied(i,j) * 86400.  ! runoff_applied passed in m/s; for Rignot equation convert to [m/d] 
-              
-             ! Adding frontal melt factor in line with suggested ISMIP7 retuning: * a factor 1.64 for calibration to new data; * a factor 2.0 for resolution dependence for 4 km; 
-             ! * a factor 0.8 for annual vs monthly forcing data.
-             m_sr = (1.64 * 2.0 * 0.8) * (3.0 * 1.0e-4 * thck_effective(i,j) * q_sr**0.39 + 0.15) * tf_sr**1.18 * 365./scyr ! retuned Rignot et al. 2016; formulted in m/d, converted to m/s
+
+             ! Rignot et al. 2016; formulted in m/d, converted to m/s. Mulitplier frontal_melt_factor as proposed for ISMIP7
+             m_sr = frontal_melt_factor * (3.0 * 1.0e-4 * thck_effective(i,j) * q_sr**0.39 + 0.15) * tf_sr**1.18 * 365./scyr 
 
              ! calculate applied thickness change and limit by local thickness
              melt_thck(i,j) = min((m_sr*dt * thck_effective(i,j) * cf_length(i,j)) / (dx*dy), thck(i,j))


### PR DESCRIPTION
As discussed during the last core meeting, we need a way to tune the melt sensitivity of the Greenland ocean forcing. This was hardcoded in a former commit, but we need more flexibility. This PR addresses this.
There will be a matching PR to the CISM_wrapper to just add one namelist parameter in the wrapper to control the CISM melt parameter. 

With this change here, the parameter is reset back to its standard value of 1.0, which reduces the melt sensitivity and leads to less mass loss during spinup. It is therefore answer-changing. 

I have run the standard tests suite aux_cism_noresm with all passes. Comparison to the baseline show differences as expected.  
