### PR TITLE
add flux diagnostics

### DIFF
--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -195,12 +195,14 @@ contains
          tot_smb_flux,                  &    ! total surface mass balance flux (kg/s)
          tot_bmb_flux,                  &    ! total basal mass balance flux (kg/s)
          tot_calving_flux,              &    ! total calving flux (kg/s)
+         tot_frontal_melt_flux,         &    ! total frontal melt flux (kg/s)
          tot_forceretreat_flux,         &    ! total force retreat flux (kg/s)
          tot_rmicecap_flux,             &    ! total ice cap removal flux (kg/s)
          tot_gl_flux,                   &    ! total grounding line flux (kg/s)
          tot_acab,                      &    ! total surface accumulation/ablation rate (m^3/yr)
          tot_bmlt,                      &    ! total basal melt rate (m^3/yr)
          tot_calving,                   &    ! total calving rate (m^3/yr)
+         tot_frontal_melt,              &    ! total frontal melt rate (m^3/yr)
          tot_dmass_dt,                  &    ! rate of change of total mass (kg/s)
          err_dmass_dt,                  &    ! mass conservation error (kg/s)
                                              ! given by dmass_dt - (tot_acab - tot_bmlt - tot_calving)
@@ -549,6 +551,20 @@ contains
 
        ! total calving mass balance flux (kg/s, negative for ice loss by calving)
        tot_calving_flux = -tot_calving * rhoi / scyr   ! convert m^3/yr to kg/s
+
+       ! total frontal melt rate (m^3/yr ice)
+       ! Note: calving%melt_rate has units of m/yr ice
+
+       tot_frontal_melt = 0.d0
+       do j = lhalo+1, nsn-uhalo
+          do i = lhalo+1, ewn-uhalo
+             tot_frontal_melt = tot_frontal_melt + model%calving%melt_rate(i,j) * cell_area(i,j)  ! m^3/yr ice
+          enddo
+       enddo
+       tot_frontal_melt = parallel_reduce_sum(tot_frontal_melt)
+
+       ! total calving mass balance flux (kg/s, negative for ice loss by frontal melt)
+       tot_frontal_melt_flux = -tot_frontal_melt * rhoi / scyr   ! convert m^3/yr to kg/s
 
        ! total force retreat and ice cap removal fluxes (kg/s, negative for ice loss)
        ! Note: forceretreat_flux and rmicecap_flux are in kg/m^2/s; multiply by cell_area to get kg/s

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1322,12 +1322,14 @@ module glide_types
     real(dp) :: total_smb_flux         ! total surface mass balance flux (kg/s)
     real(dp) :: total_bmb_flux         ! total basal mass balance flux (kg/s)
     real(dp) :: total_calving_flux     ! total calving mass flux (kg/s)
+    real(dp) :: total_frontal_melt_flux     ! total frontal melt flux (kg/s)
     real(dp) :: total_forceretreat_flux! total flux due to force retreat (kg/s) 
     real(dp) :: total_rmicecap_flux    ! total flux due to ice cap removal (kg/s) 
     real(dp) :: total_gl_flux          ! total grounding line mass flux (kg/s)
     real(dp) :: total_smb_flux_tavg    ! total surface mass balance flux (kg/s), time average
     real(dp) :: total_bmb_flux_tavg    ! total basal mass balance flux (kg/s), time average
     real(dp) :: total_calving_flux_tavg! total calving mass flux (kg/s), time average
+    real(dp) :: total_frontal_melt_flux_tavg     ! total frontal melt flux (kg/s), time average
     real(dp) :: total_forceretreat_flux_tavg ! total flux due to force retreat (kg/s), time average
     real(dp) :: total_rmicecap_flux_tavg     ! total flux due to ice cap removal (kg/s), time average
     real(dp) :: total_gl_flux_tavg     ! total grounding line mass flux (kg/s), time average
@@ -1587,6 +1589,10 @@ module glide_types
      real(dp),dimension(:,:),  pointer :: calving_rate => null()   !> rate of ice loss due to calving (m/yr ice)
      real(dp),dimension(:,:),  pointer :: calving_rate_tavg => null()  !> rate of ice loss due to calving (m/yr ice, time average)
      integer, dimension(:,:),  pointer :: calving_mask => null()   !> calve floating ice where the mask = 1 (whichcalving = CALVING_GRID_MASK)
+     real(dp),dimension(:,:),  pointer :: forceretreat_rate => null()   !> rate of ice loss due to force retreat (m/yr ice)
+     real(dp),dimension(:,:),  pointer :: forceretreat_rate_tavg => null()  !> rate of ice loss due to force retreat (m/yr ice, time average)
+     real(dp),dimension(:,:),  pointer :: rmicecap_rate => null()   !> rate of ice loss due to ice cap removal (m/yr ice)
+     real(dp),dimension(:,:),  pointer :: rmicecap_rate_tavg => null()  !> rate of ice loss due to ice cap removal (m/yr ice, time average)
      integer, dimension(:,:),  pointer :: protected_mask => null() !> mask of cells protected from calving when using the subgrid CF scheme
      real(dp),dimension(:,:),  pointer :: melt_thck => null()      !> thickness loss in grid cell due to frontal melt
                                                                    !> scaled by thk0 like mass balance, thickness, etc.
@@ -3343,6 +3349,10 @@ contains
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_rate_tavg)
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_mask)
     call coordsystem_allocate(model%general%ice_grid, model%calving%calving_front_mask)
+    call coordsystem_allocate(model%general%ice_grid, model%calving%forceretreat_rate)
+    call coordsystem_allocate(model%general%ice_grid, model%calving%forceretreat_rate_tavg)
+    call coordsystem_allocate(model%general%ice_grid, model%calving%rmicecap_rate)
+    call coordsystem_allocate(model%general%ice_grid, model%calving%rmicecap_rate_tavg)
     call coordsystem_allocate(model%general%ice_grid, model%calving%melt_thck)
     call coordsystem_allocate(model%general%ice_grid, model%calving%melt_rate)
     call coordsystem_allocate(model%general%ice_grid, model%calving%melt_rate_tavg)
@@ -4023,6 +4033,14 @@ contains
         deallocate(model%calving%calving_mask)
     if (associated(model%calving%calving_front_mask)) &
         deallocate(model%calving%calving_front_mask)
+    if (associated(model%calving%forceretreat_rate)) &
+        deallocate(model%calving%forceretreat_rate)
+    if (associated(model%calving%forceretreat_rate_tavg)) &
+        deallocate(model%calving%forceretreat_rate_tavg)
+    if (associated(model%calving%rmicecap_rate)) &
+        deallocate(model%calving%rmicecap_rate)
+    if (associated(model%calving%rmicecap_rate_tavg)) &
+        deallocate(model%calving%rmicecap_rate_tavg)
     if (associated(model%calving%melt_thck)) &
         deallocate(model%calving%melt_thck)
     if (associated(model%calving%melt_rate)) &

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -608,6 +608,20 @@ data:          data%calving%calving_front_mask
 load:          1
 type:          int
 
+[forceretreat_rate]
+dimensions:    time, y1, x1
+units:         meter/year
+long_name:     rate of mass loss by forced retreat
+data:          data%calving%forceretreat_rate
+average:       1
+
+[rmicecap_rate]
+dimensions:    time, y1, x1
+units:         meter/year
+long_name:     rate of mass loss by ice cap removal 
+data:          data%calving%rmicecap_rate
+average:       1
+
 [thck_effective]
 dimensions:    time, y1, x1
 units:         meter
@@ -710,6 +724,13 @@ dimensions:    time
 units:         kg/s
 long_name:     mass flux removed by force_retreat method
 data:          data%geometry%total_forceretreat_flux
+average:       1
+
+[total_frontal_melt_flux]
+dimensions:    time
+units:         kg/s
+long_name:     total frontal melt flux
+data:          data%geometry%total_frontal_melt_flux
 average:       1
 
 [total_rmicecap_flux]

--- a/libglimmer/glimmer_config.F90
+++ b/libglimmer/glimmer_config.F90
@@ -138,7 +138,7 @@ contains
     config=>NULL()
     this_section=>NULL()
     do while(ios == 0)
-       if (main_task) read(unit,fmt='(a450)',iostat=ios) line
+       if (main_task) read(unit,fmt='(a1050)',iostat=ios) line
        call broadcast(line)
        call broadcast(ios)
        line = adjustl(line)

--- a/libglimmer/glimmer_config.F90
+++ b/libglimmer/glimmer_config.F90
@@ -58,7 +58,7 @@ module glimmer_config
   private :: handle_section, handle_value, InsertSection, InsertValue, dp
 
   integer, parameter :: namelen=50                 !< the maximum length of key or section
-  integer, parameter :: valuelen=400               !< the maximum length of a value
+  integer, parameter :: valuelen=1000               !< the maximum length of a value
   integer, parameter :: linelen=valuelen+namelen+1 !< the maximum length of a line
   
   !> derived type defining a key-value pair

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -3888,6 +3888,12 @@ contains
     ! calving rate (m/yr ice; positive for calving)
     model%calving%calving_rate(:,:) = model%calving%calving_thck(:,:) / (model%numerics%dt/scyr)
  
+    ! forceretreat rate (m/yr ice; positive for retreat)
+    model%calving%forceretreat_rate(:,:) = model%calving%forceretreat_thck(:,:) / (model%numerics%dt/scyr)
+ 
+    ! rmicecap rate (m/yr ice; positive for removal)
+    model%calving%rmicecap_rate(:,:) = model%calving%rmicecap_thck(:,:) / (model%numerics%dt/scyr)
+ 
     ! melt rate (m/yr ice; positive for melt)
     model%calving%melt_rate(:,:) = model%calving%melt_thck(:,:) / (model%numerics%dt/scyr)
 


### PR DESCRIPTION
This PR brings in all the flux diagnostics needed to close the mass budget in the output files.
There is a matching PR for the wrapper in the making (NorESMhub/CISM-wrapper#23).

The available scalar variables that are needed to close the budget are
        double total_bmb_flux_tavg(time) ;
        double total_calving_flux_tavg(time) ;
        double total_forceretreat_flux_tavg(time) ;
        double total_frontal_melt_flux_tavg(time) ;
        double total_rmicecap_flux_tavg(time) ;
        double total_smb_flux_tavg(time) ;

In addition there is diagnostic  total_gl_flux_tavg, not needed to close the mass budget.

All the regular tests in aux_cism_noresm pass. 
NLCOMP fail as expected 
DIFF fail as expected 
I also got fails in TPUTCOMP, I think because the tests are very short runs and I write a few more variables than before. Also expected.
