### PR TITLE
clamp tf_sr and q_sr to >= 0 in fullgrid_ismip6_submarine_melt

### DIFF
--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -2968,11 +2968,17 @@ contains
              !tf_sr = 2.0 ! hard coding a cold cavity thermal forcing of 2 degC
              !q_sr = 10.0 ! hard coding a runoff of 400 m3/s multiplied by s/day and divided by cross-sectional area of 700m*5000m [m/day] 
 
-             tf_sr = thermal_forcing_applied(i,j) ! 2d thermal forcing [degC]
-             q_sr = runoff_applied(i,j) * 86400.  ! runoff_applied passed in m/s; for Rignot equation convert to [m/d] 
+             ! 2d thermal forcing [degC] and runoff [m/d] for the Rignot et al. 2016
+             ! parameterization. Both must be clamped >= 0 because the formula uses
+             ! non-integer powers (q_sr**0.39 and tf_sr**1.18) — a non-integer power
+             ! of a negative number is NaN and signals SIGFPE. Physically, the Rignot
+             ! formula isn't defined for cold-cavity (negative TF) or non-positive
+             ! discharge: no submarine melt should be applied in those conditions.
+             tf_sr = max(thermal_forcing_applied(i,j), 0.d0)
+             q_sr  = max(runoff_applied(i,j) * 86400., 0.d0)
 
-             ! Rignot et al. 2016; formulted in m/d, converted to m/s. Mulitplier frontal_melt_factor as proposed for ISMIP7
-             m_sr = frontal_melt_factor * (3.0 * 1.0e-4 * thck_effective(i,j) * q_sr**0.39 + 0.15) * tf_sr**1.18 * 365./scyr 
+             ! Rignot et al. 2016; formulated in m/d, converted to m/s. Multiplier frontal_melt_factor as proposed for ISMIP7
+             m_sr = frontal_melt_factor * (3.0 * 1.0e-4 * thck_effective(i,j) * q_sr**0.39 + 0.15) * tf_sr**1.18 * 365./scyr
 
              ! calculate applied thickness change and limit by local thickness
              melt_thck(i,j) = min((m_sr*dt * thck_effective(i,j) * cf_length(i,j)) / (dx*dy), thck(i,j))


### PR DESCRIPTION
 Rignot et al. (2016) uses non-integer powers (q_sr**0.39, tf_sr**1.18).  A non-integer power of a negative number is NaN and signals SIGFPE.  Cold-cavity thermal forcing (TF < 0) and zero/negative subglacial discharge are physically outside the parameterization's domain; clamping to 0 turns  off frontal melt in those cells, which is the correct physical behavior.

This PR resolves #15 