### PR TITLE
Fix to include rmicecap, forceretreat in solid runoff

### DIFF
--- a/libglad/glad_output_fluxes.F90
+++ b/libglad/glad_output_fluxes.F90
@@ -95,8 +95,10 @@ contains
     !                Divide by dt to convert to kg/m^2/s
 
     ! Convert to kg/m^2/s
-    output_fluxes%rofi_sum(:,:) = output_fluxes%rofi_sum(:,:)  &
-         + model%calving%calving_thck(:,:) * rhoi / model%numerics%dt
+    output_fluxes%rofi_sum(:,:) = output_fluxes%rofi_sum(:,:)         &
+       + ( model%calving%calving_thck(:,:)                            &
+       + model%calving%forceretreat_thck(:,:)                         &
+       + model%calving%rmicecap_thck(:,:) ) * rhoi / model%numerics%dt
 
     !--------------------------------------------------------------------
     ! Accumulate liquid runoff (basal melting)

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -637,6 +637,7 @@ contains
        model%geometry%total_forceretreat_flux = tot_forceretreat_flux
        model%geometry%total_rmicecap_flux = tot_rmicecap_flux
        model%geometry%total_gl_flux = tot_gl_flux
+       model%geometry%total_frontal_melt_flux = tot_frontal_melt_flux
 
     endif  ! Glissade dycore
 


### PR DESCRIPTION
@TomasTorsvik, @hgoelzer and me found a small bug affecting solid runoff being sent to BLOM through MOSART, which can be fixed by a one-liner which is included in this commit. We probably are not in time for beta20, but this update to source_cism  should go in the next tag. For now, we will use a noresm version that includes this fix to run test simulations (preind. and historical) for beta20 with interactive GrIS. @mvertens @mvdebolskiy 